### PR TITLE
Remove MockerFixture import

### DIFF
--- a/tests/test_DomainHustler.py
+++ b/tests/test_DomainHustler.py
@@ -1,5 +1,4 @@
 import pytest
-from pytest_mock import MockerFixture
 import DomainHustler
 
 def test_resolve_dns(mocker):


### PR DESCRIPTION
## Summary
- remove unused `MockerFixture` import from tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'DomainHustler')*

------
https://chatgpt.com/codex/tasks/task_e_6870749d498c832fb33fd7858e30856a