### PR TITLE
Fix README install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A lightweight tool written in Python3 for hustling information from a domain. It
 Ensure you have the required libraries installed:
 
 ```bash
-pip install dnspython whois python-whis requests
+pip install dnspython whois python-whois requests
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary
- fix a typo in the installation instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dns')*

------
https://chatgpt.com/codex/tasks/task_e_687077e524ec832f94372c4585fdcec9