### PR TITLE
Fix duplicate logic in subdomain error test

### DIFF
--- a/tests/test_DomainHustler.py
+++ b/tests/test_DomainHustler.py
@@ -58,9 +58,3 @@ def test_get_subdomains_error(mocker):
     domain = 'example.com'
     subdomains = DomainHustler.get_subdomains(domain)
     assert "Error retrieving subdomains" in subdomains
-
-
-    mock_get.side_effect = Exception("Request failed")
-    domain = 'example.com'
-    subdomains = DomainHustler.get_subdomains(domain)
-    assert "Error retrieving subdomains" in subdomains


### PR DESCRIPTION
## Summary
- remove repeated block in `test_get_subdomains_error`

## Testing
- `PYTHONPATH=. pytest -q` *(fails: No module named 'dns')*

------
https://chatgpt.com/codex/tasks/task_e_6870790cc2c0832fa749f41040883f4d